### PR TITLE
Fix GitHub README fetch for /api/canon

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,16 +16,21 @@ app.use(express.static('public'));
 
 app.get('/api/canon', async (req, res) => {
     try {
+        const headers = {
+            'Accept': 'application/vnd.github.raw',
+            'User-Agent': 'Alien-Worlds-Lore-App'
+        };
+
+        if (GITHUB_TOKEN) {
+            headers['Authorization'] = `token ${GITHUB_TOKEN}`;
+        }
+
         const response = await fetch('https://api.github.com/repos/Alien-Worlds/the-lore/contents/README.md?ref=main', {
-            headers: {
-                'Accept': 'application/vnd.github.raw+json',
-                'Authorization': `Bearer ${GITHUB_TOKEN}`,
-                'User-Agent': 'Alien-Worlds-Lore-App'
-            }
+            headers
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const text = await response.text();
-        res.send(text);
+        res.type('text/markdown').send(text);
     } catch (error) {
         console.error('Error fetching Canon lore:', error);
         res.status(500).send('Error fetching Canon lore');


### PR DESCRIPTION
## Summary
- authenticate `/api/canon` GitHub call using `GITHUB_TOKEN`
- send `Accept: application/vnd.github.raw` and return markdown content type

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68554a837f78832a99e931da62871cc8