### PR TITLE
Fix ES module imports in server

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,8 +1,13 @@
 // server.js
-const express = require('express');
-const dotenv = require('dotenv');
-const fetch = require('node-fetch');
-const path = require('path');
+import express from 'express';
+import dotenv from 'dotenv';
+import fetch from 'node-fetch';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 dotenv.config();
 const app = express();
@@ -94,7 +99,7 @@ app.get('/api/contents', async (req, res) => {
 });
 
 // SPA fallback — always serve index.html
-app.get('*', (req, res) => {
+app.use((req, res) => {
     res.sendFile(path.resolve(__dirname, 'public', 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- convert `require` and `module.exports` usage in `server.js` to ES module syntax
- update SPA fallback to use `app.use` so Express v5 starts correctly

## Testing
- `npm run build`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68554c78f148832abc4ddd6018088129