### PR TITLE
Fix dev server networking and asset paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@wharfkit/wallet-plugin-cloudwallet": "^1.0.3",
         "dotenv": "^16.4.7",
         "express": "^5.1.0",
+        "https-proxy-agent": "^7.0.6",
         "node-fetch": "^2.7.0"
       },
       "devDependencies": {
@@ -818,6 +819,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1482,6 +1492,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@wharfkit/wallet-plugin-cloudwallet": "^1.0.3",
     "dotenv": "^16.4.7",
     "express": "^5.1.0",
+    "https-proxy-agent": "^7.0.6",
     "node-fetch": "^2.7.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import fetch from 'node-fetch';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
@@ -11,8 +12,10 @@ const __dirname = dirname(__filename);
 
 dotenv.config();
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 5174;
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
 
 // Serve static frontend (from Vite build output or raw public)
 app.use(express.static('public'));
@@ -31,7 +34,8 @@ app.get('/api/canon', async (req, res) => {
         }
 
         const response = await fetch('https://api.github.com/repos/Alien-Worlds/the-lore/contents/README.md?ref=main', {
-            headers
+            headers,
+            agent
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const text = await response.text();
@@ -49,7 +53,8 @@ app.get('/api/proposed', async (req, res) => {
                 'Accept': 'application/vnd.github+json',
                 'Authorization': `Bearer ${GITHUB_TOKEN}`,
                 'User-Agent': 'Alien-Worlds-Lore-App'
-            }
+            },
+            agent
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const pulls = await response.json();
@@ -68,7 +73,8 @@ app.get('/api/pulls/:number/files', async (req, res) => {
                 'Accept': 'application/vnd.github+json',
                 'Authorization': `Bearer ${GITHUB_TOKEN}`,
                 'User-Agent': 'Alien-Worlds-Lore-App'
-            }
+            },
+            agent
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const files = await response.json();
@@ -87,7 +93,8 @@ app.get('/api/contents', async (req, res) => {
                 'Accept': 'application/vnd.github.raw+json',
                 'Authorization': `Bearer ${GITHUB_TOKEN}`,
                 'User-Agent': 'Alien-Worlds-Lore-App'
-            }
+            },
+            agent
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const content = await response.text();

--- a/src/styles.css
+++ b/src/styles.css
@@ -64,7 +64,7 @@ html, body {
   margin: 5vh auto;
   background: #1A1410;
   border: 1vw solid transparent;
-  border-image: url('assets/sci-fi-frame.png') 30 stretch;
+  border-image: url('/assets/sci-fi-frame.png') 30 stretch;
   box-shadow: 0 0 1vw rgba(255, 158, 66, 0.3);
   display: flex;
   flex-direction: column;
@@ -117,7 +117,7 @@ html, body {
   color: #FFEEDC;
   padding: 1vw;
   border: 2px solid transparent;
-  border-image: url('assets/sci-fi-frame.png') 30 stretch;
+  border-image: url('/assets/sci-fi-frame.png') 30 stretch;
   font-size: 1vw;
   text-transform: uppercase;
   cursor: pointer;


### PR DESCRIPTION
## Summary
- proxy GitHub API requests through `https-proxy-agent`
- make server port configurable and default to 5174
- update asset paths for build compatibility
- add `https-proxy-agent` dependency

## Testing
- `npm run build`
- `npm run dev` then `curl -I http://localhost:3000/api/canon`

------
https://chatgpt.com/codex/tasks/task_e_68555007aa88832a8dcf5ab4884a827f