### PR TITLE
Fix login, GraphQL handling, and UI updates

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -6,11 +6,47 @@ async function getKit() {
     if (kit) return kit;
     const { SessionKit } = await import('@wharfkit/session');
     const { WalletPluginCloudWallet } = await import('@wharfkit/wallet-plugin-cloudwallet');
+
+    class SimpleUI {
+        constructor(requireChainSelect = false) {
+            this.requireChainSelect = requireChainSelect;
+        }
+        async login(context) {
+            return {
+                chainId: context.chains[0].id,
+                walletPluginIndex: 0,
+                permissionLevel: context.permissionLevel
+            };
+        }
+        async onError(error) { console.error('SessionKit UI error:', error); }
+        async onAccountCreate() {}
+        async onAccountCreateComplete() {}
+        async onLogin() {}
+        async onLoginComplete() {}
+        async onTransact() {}
+        async onTransactComplete() {}
+        async onSign() {}
+        async onSignComplete() {}
+        async onBroadcast() {}
+        async onBroadcastComplete() {}
+        prompt() { return { result: Promise.resolve(null), cancel: () => {} }; }
+        status() {}
+        translate(key) { return key; }
+        getTranslate() { return (key) => key; }
+        addTranslations() {}
+    }
+
     const walletPlugin = new WalletPluginCloudWallet();
     kit = new SessionKit({
         appName: 'A01 Terminal',
-        chains: [{ id: '1064487b3cd1a897c10f3fa6b05b68f29ed27b5c46e81d7b78c4f2b5ab17e7f9', url: 'https://wax.greymass.com' }],
-        ui: { requireChainSelect: false },
+        chains: [
+            {
+                id: '1064487b3cd1a897c10f3fa6b05b68f29ed27b5c46e81d7b78c4f2b5ab17e7f9',
+                url: 'https://wax.greymass.com'
+            }
+        ],
+        ui: new SimpleUI(false),
+        uiRequirements: { requiresChainSelect: false, requiresWalletSelect: false },
         walletPlugins: [walletPlugin]
     });
     return kit;

--- a/src/graphqlMegaFetcher.js
+++ b/src/graphqlMegaFetcher.js
@@ -1,14 +1,19 @@
 export const API_URL = 'https://api.alienworlds.io/graphql/graphql';
 
 async function graphqlRequest(query, variables = {}) {
-  const response = await fetch(API_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Accept': 'application/json'
-    },
-    body: JSON.stringify({ query, variables })
-  });
+  let response;
+  try {
+    response = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      body: JSON.stringify({ query, variables })
+    });
+  } catch (err) {
+    throw new Error('Network error: ' + err.message);
+  }
 
   const text = await response.text();
 
@@ -20,7 +25,8 @@ async function graphqlRequest(query, variables = {}) {
   try {
     json = JSON.parse(text);
   } catch (e) {
-    throw new Error('Invalid JSON response: ' + text.slice(0, 100));
+    console.error('Non-JSON response:', text);
+    throw new Error('Invalid JSON response');
   }
 
   if (json.errors) {

--- a/src/library.js
+++ b/src/library.js
@@ -207,6 +207,10 @@ export class Library {
         extraTags.forEach(t => extraList.appendChild(buildBtn(t)));
         if (extraTags.length) {
             extraWrap.style.display = 'block';
+            extraWrap.open = false;
+            if (extraTags.length > 20) {
+                extraWrap.querySelector('summary').textContent = 'Show Filters';
+            }
         } else if (extraWrap) {
             extraWrap.style.display = 'none';
         }

--- a/src/loreIndex.js
+++ b/src/loreIndex.js
@@ -5,7 +5,7 @@ export function indexLore(canonSections, proposedContents) {
     // Index Canon Lore
     canonSections.forEach((section, idx) => {
         const sectionId = `canon-${idx}`;
-        const tags = extractTags(section.content);
+        const tags = extractTags(section.content, section.metadata);
         index[sectionId] = {
             ...section,
             sectionId: sectionId,
@@ -19,7 +19,7 @@ export function indexLore(canonSections, proposedContents) {
     proposedContents.forEach((proposal, proposalIdx) => {
         proposal.sections.forEach((section, sectionIdx) => {
             const sectionId = `proposed-${proposal.prNumber}-${sectionIdx}`;
-            const tags = extractTags(section.content);
+            const tags = extractTags(section.content, section.metadata);
             index[sectionId] = {
                 ...section,
                 sectionId: sectionId,
@@ -43,16 +43,30 @@ export function indexLore(canonSections, proposedContents) {
     return index;
 }
 
-export function extractTags(content) {
-    const words = content.toLowerCase().split(/\W+/);
-    const stopWords = new Set(['the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for', 'of', 'with', 'by']);
-    const tags = words
-        .filter(word => word.length > 3 && !stopWords.has(word))
-        .reduce((acc, word) => {
-            acc[word] = (acc[word] || 0) + 1;
-            return acc;
-        }, {});
-    return Object.keys(tags).sort((a, b) => tags[b] - tags[a]).slice(0, 5);
+export function extractTags(content, metadata = {}) {
+    const stopWords = new Set([
+        'the','a','an','and','or','but','in','on','at','to','for','of','with','by',
+        'this','that','these','those','is','are','was','were','be','has','have','had','they','them'
+    ]);
+
+    const tagSet = new Set();
+
+    if (metadata.tags) {
+        const parts = String(metadata.tags)
+            .split(/[,;]+/)
+            .map(t => t.trim().toLowerCase())
+            .filter(t => t && !stopWords.has(t));
+        parts.forEach(t => tagSet.add(t));
+    }
+
+    content
+        .toLowerCase()
+        .split(/\W+/)
+        .forEach(word => {
+            if (word.length > 3 && !stopWords.has(word)) tagSet.add(word);
+        });
+
+    return Array.from(tagSet).slice(0, 5);
 }
 
 function chunkContent(content) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -435,7 +435,8 @@ html, body {
 }
 .planet-icon img,
 .planet-img {
-  filter: grayscale(1) brightness(1.15) hue-rotate(35deg) saturate(140%);
+  width: 90%;
+  filter: hue-rotate(30deg) saturate(3);
 }
 .planet {
   position: absolute;

--- a/src/vote.js
+++ b/src/vote.js
@@ -26,11 +26,14 @@ export async function renderVoteSidebar(elementId = 'loreNav') {
     try {
         const data = await fetchDaoInfo();
         const proposals = data?.TokeLore?.proposals || [];
-        if (!proposals.length) {
-            el.innerHTML = '<p>No active proposals</p>';
+        const wallet = sessionStorage.getItem('WAX_WALLET');
+        const voted = wallet ? new Set(JSON.parse(localStorage.getItem(`A01_VOTES_${wallet}`) || '[]')) : new Set();
+        const votedProposals = proposals.filter(p => voted.has(p.id));
+        if (!votedProposals.length) {
+            el.innerHTML = '<p>No voted proposals</p>';
             return;
         }
-        el.innerHTML = '<ul>' + proposals.map(p => `<li>${p.title}</li>`).join('') + '</ul>';
+        el.innerHTML = '<ul>' + votedProposals.map(p => `<li>${p.title}</li>`).join('') + '</ul>';
     } catch (err) {
         el.innerHTML = '<p>Error loading proposals</p>';
         console.error('Vote sidebar error:', err);


### PR DESCRIPTION
## Summary
- patch WAX login handler for SessionKit
- improve GraphQL error handling
- refine tag filter logic and add toggle
- scale planet icons and apply orange hue
- filter votes sidebar to show only voted proposals

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68557b5488ac832a88d339ccdad0a189