### PR TITLE
Fix CORS issue by proxying GraphQL

### DIFF
--- a/src/graphqlMegaFetcher.js
+++ b/src/graphqlMegaFetcher.js
@@ -1,4 +1,5 @@
-export const API_URL = 'https://api.alienworlds.io/graphql';
+// Use local proxy to avoid browser CORS restrictions
+export const API_URL = '/api/graphql';
 
 // === CACHING UTILITIES ===
 function getCacheKey(query, variables) {


### PR DESCRIPTION
## Summary
- add JSON parser middleware and proxy `/api/graphql` route on the Express server
- point frontend GraphQL fetcher at the new local API

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685585969c94832a9e52a92cbc3e710e