### PR TITLE
Fix GraphQL proxy, login, and map layout

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -13,13 +13,9 @@ function getKit() {
   if (!sessionKit) {
     const walletPlugin = new WalletPluginCloudWallet()
     sessionKit = new SessionKit({
-      appName: 'A-01 Canon Terminal',
+      appName: 'A01 Terminal',
       chains: [CHAIN],
-      walletPlugins: [walletPlugin],
-      ui: {
-        render: () => {},
-        onError: (error) => console.error('[SessionKit UI Error]', error)
-      }
+      walletPlugins: [walletPlugin]
     })
   }
   return sessionKit

--- a/src/graphqlMegaFetcher.js
+++ b/src/graphqlMegaFetcher.js
@@ -1,5 +1,5 @@
-// Use local proxy to avoid browser CORS restrictions
-export const API_URL = '/api/graphql';
+// GraphQL endpoint routed through Vite dev proxy
+export const API_URL = '/aw-graphql';
 
 // === CACHING UTILITIES ===
 function getCacheKey(query, variables) {

--- a/src/maps.js
+++ b/src/maps.js
@@ -71,7 +71,7 @@ export class Maps {
 
       el.addEventListener('mouseenter', () => {
         tooltip.innerHTML = `<strong>${name}</strong><br>${data.short.join('<br>')}`;
-        tooltip.style.left = `${el.offsetLeft + 60}px`;
+        tooltip.style.left = `${el.offsetLeft + el.offsetWidth / 2 + 8}px`;
         tooltip.style.top = `${el.offsetTop - 10}px`;
         tooltip.hidden = false;
       });

--- a/src/planet-data.js
+++ b/src/planet-data.js
@@ -76,7 +76,7 @@ export const PLANET_DATA = {
   },
 
   Veles: {
-    orbitCoords: [880, 360],
+    orbitCoords: [830, 340],
     short: [
       "Archive World",
       "AI Vaults",
@@ -95,7 +95,7 @@ export const PLANET_DATA = {
   },
 
   Neri: {
-    orbitCoords: [400, 500],
+    orbitCoords: [420, 480],
     short: [
       "Oceanic Depths",
       "Hidden Factions",

--- a/src/styles.css
+++ b/src/styles.css
@@ -427,16 +427,21 @@ html, body {
   width: 100%;
   height: 100%;
   object-fit: contain;
-  filter: grayscale(1) brightness(1.15) hue-rotate(35deg) saturate(140%);
+  filter: grayscale(1) brightness(1.2) hue-rotate(40deg) saturate(160%);
   pointer-events: none;
 }
 .map-space img {
-  filter: grayscale(1) brightness(1.15) hue-rotate(35deg) saturate(140%);
+  filter: grayscale(1) brightness(1.2) hue-rotate(40deg) saturate(160%);
+}
+.planet-icon {
+  position: absolute;
+  width: 72px;
+  height: 72px;
 }
 .planet-icon img,
 .planet-img {
-  width: 90%;
-  filter: hue-rotate(30deg) saturate(3);
+  width: 100%;
+  filter: hue-rotate(40deg) saturate(4);
 }
 .planet {
   position: absolute;
@@ -472,6 +477,17 @@ html, body {
   white-space: pre-line;
   text-align: center;
   z-index: 5;
+}
+.planet-tooltip {
+  position: absolute;
+  background: #1A1410;
+  border: 1px solid #FF9E42;
+  color: #FFEEDC;
+  padding: 0.3vw 0.6vw;
+  font-size: 0.9vw;
+  white-space: pre-line;
+  pointer-events: none;
+  z-index: 10;
 }
 .planet-detail {
   position: absolute;

--- a/vite.config.js
+++ b/vite.config.js
@@ -16,6 +16,11 @@ export default defineConfig({
         target: 'http://localhost:5174',
         changeOrigin: true,
         secure: false
+      },
+      '/aw-graphql': {
+        target: 'https://api.alienworlds.io/graphql',
+        changeOrigin: true,
+        secure: false
       }
     }
   }


### PR DESCRIPTION
## Summary
- configure vite dev proxy for Alien Worlds API
- route GraphQL requests through `/aw-graphql`
- simplify SessionKit init for WAX login
- tweak planet layout and tooltip positioning
- adjust planet styles for consistent sizing and hue

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855c42a98bc832abe242db0e726974b