### PR TITLE
Add DAO proposal fetcher

### DIFF
--- a/src/daoProposals.js
+++ b/src/daoProposals.js
@@ -1,0 +1,41 @@
+// daoProposals.js
+// Fetch proposals from the Alien Worlds DAO GraphQL API
+
+const DAO_GRAPHQL_ENDPOINT = 'https://dao.alienworlds.io/graphql';
+
+export async function fetchDaoProposals() {
+  const query = `
+    query {
+      proposals(limit: 50) {
+        id
+        title
+        author
+        created_at
+        status
+      }
+    }`;
+
+  const response = await fetch(DAO_GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    },
+    body: JSON.stringify({ query })
+  });
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${text.slice(0, 100)}`);
+  }
+
+  const json = JSON.parse(text);
+
+  if (json.errors) {
+    const message = json.errors.map(e => e.message).join(', ');
+    throw new Error(message);
+  }
+
+  return json.data;
+}


### PR DESCRIPTION
## Summary
- implement `fetchDaoProposals` to query `dao.alienworlds.io`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f4a636ebc832abcebc23d69d91903