### PR TITLE
Add GitHub PR fetch helper

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -1,0 +1,26 @@
+// github.js
+// Fetches open pull requests from the alien-worlds/aw-lore repository.
+// Returns title, url, author and creation date for each PR.
+
+export async function fetchOpenPullRequests() {
+  const url = 'https://api.github.com/repos/alien-worlds/aw-lore/pulls?state=open';
+
+  const response = await fetch(url, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': 'A01-Lore-App'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API error: HTTP ${response.status}`);
+  }
+
+  const pulls = await response.json();
+  return pulls.map(pr => ({
+    title: pr.title,
+    url: pr.html_url,
+    author: pr.user?.login,
+    created_at: pr.created_at
+  }));
+}


### PR DESCRIPTION
## Summary
- add a helper that fetches open pull requests from `alien-worlds/aw-lore`

## Testing
- `npm run build`
- `node - <<'NODE'
import { fetchOpenPullRequests } from './src/github.js';
const prs = await fetchOpenPullRequests();
console.log(prs.slice(0,2));
NODE` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687f4abe05ec832ab2c89089e965f832