### PR TITLE
Remove Node Buffer dependency

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,3 +1,5 @@
+import { installBufferPolyfill } from './bufferPolyfill.js'
+installBufferPolyfill()
 import { SessionKit } from '@wharfkit/session'
 import { WalletPluginCloudWallet } from '@wharfkit/wallet-plugin-cloudwallet'
 

--- a/src/bufferPolyfill.js
+++ b/src/bufferPolyfill.js
@@ -1,0 +1,44 @@
+export class BufferPolyfill extends Uint8Array {
+  static from(value, encoding) {
+    if (typeof value === 'number') {
+      const arr = new Uint8Array(value);
+      return new BufferPolyfill(arr.buffer);
+    }
+    if (typeof value === 'string') {
+      if (encoding === 'base64') {
+        const binary = atob(value);
+        const arr = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+          arr[i] = binary.charCodeAt(i);
+        }
+        return new BufferPolyfill(arr.buffer);
+      }
+      if (!encoding || encoding === 'utf8' || encoding === 'utf-8') {
+        return new BufferPolyfill(new TextEncoder().encode(value).buffer);
+      }
+    }
+    if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+      return new BufferPolyfill(value.buffer || value);
+    }
+    throw new Error('Unsupported Buffer.from input');
+  }
+  toString(encoding) {
+    if (encoding === 'base64') {
+      let str = '';
+      for (let i = 0; i < this.length; i++) {
+        str += String.fromCharCode(this[i]);
+      }
+      return btoa(str);
+    }
+    if (!encoding || encoding === 'utf8' || encoding === 'utf-8') {
+      return new TextDecoder().decode(this);
+    }
+    throw new Error('Unsupported Buffer.toString encoding');
+  }
+}
+
+export function installBufferPolyfill() {
+  if (typeof globalThis.Buffer === 'undefined') {
+    globalThis.Buffer = BufferPolyfill;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -7,7 +8,20 @@ export default defineConfig({
       '@wharfkit/session',
       '@wharfkit/wallet-plugin-cloudwallet',
       '@wharfkit/antelope'
-    ]
+    ],
+    esbuildOptions: {
+      define: {
+        Buffer: 'undefined'
+      }
+    }
+  },
+  resolve: {
+    alias: {
+      buffer: path.resolve(__dirname, 'src/bufferPolyfill.js')
+    }
+  },
+  define: {
+    Buffer: 'undefined'
   },
   server: {
     port: 3000,


### PR DESCRIPTION
## Summary
- create `bufferPolyfill` to replace Node.js Buffer
- install polyfill in `auth.js`
- alias `buffer` to the polyfill in `vite.config.js`
- ensure bundling doesn't pull Node modules

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687f4ac9d0ec832a8e75edf20302022e