### PR TITLE
Fix login initialization and GitHub API headers

### DIFF
--- a/server.js
+++ b/server.js
@@ -50,12 +50,15 @@ app.get('/api/canon', async (req, res) => {
 
 app.get('/api/proposed', async (req, res) => {
     try {
+        const headers = {
+            'Accept': 'application/vnd.github+json',
+            'User-Agent': 'Alien-Worlds-Lore-App'
+        };
+        if (GITHUB_TOKEN) {
+            headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+        }
         const response = await fetch('https://api.github.com/repos/Alien-Worlds/the-lore/pulls?state=open&ref=main', {
-            headers: {
-                'Accept': 'application/vnd.github+json',
-                'Authorization': `Bearer ${GITHUB_TOKEN}`,
-                'User-Agent': 'Alien-Worlds-Lore-App'
-            },
+            headers,
             agent
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -70,12 +73,15 @@ app.get('/api/proposed', async (req, res) => {
 app.get('/api/pulls/:number/files', async (req, res) => {
     const { number } = req.params;
     try {
+        const headers = {
+            'Accept': 'application/vnd.github+json',
+            'User-Agent': 'Alien-Worlds-Lore-App'
+        };
+        if (GITHUB_TOKEN) {
+            headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+        }
         const response = await fetch(`https://api.github.com/repos/Alien-Worlds/the-lore/pulls/${number}/files`, {
-            headers: {
-                'Accept': 'application/vnd.github+json',
-                'Authorization': `Bearer ${GITHUB_TOKEN}`,
-                'User-Agent': 'Alien-Worlds-Lore-App'
-            },
+            headers,
             agent
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -90,12 +96,15 @@ app.get('/api/pulls/:number/files', async (req, res) => {
 app.get('/api/contents', async (req, res) => {
     const { url } = req.query;
     try {
+        const headers = {
+            'Accept': 'application/vnd.github.raw+json',
+            'User-Agent': 'Alien-Worlds-Lore-App'
+        };
+        if (GITHUB_TOKEN) {
+            headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`;
+        }
         const response = await fetch(url, {
-            headers: {
-                'Accept': 'application/vnd.github.raw+json',
-                'Authorization': `Bearer ${GITHUB_TOKEN}`,
-                'User-Agent': 'Alien-Worlds-Lore-App'
-            },
+            headers,
             agent
         });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/src/auth.js
+++ b/src/auth.js
@@ -2,6 +2,7 @@ import { installBufferPolyfill } from './bufferPolyfill.js'
 installBufferPolyfill()
 import { SessionKit } from '@wharfkit/session'
 import { WalletPluginCloudWallet } from '@wharfkit/wallet-plugin-cloudwallet'
+import { SimpleUI } from './simpleUI.js'
 
 let session = null
 let sessionKit
@@ -17,7 +18,8 @@ function getKit() {
     sessionKit = new SessionKit({
       appName: 'A01 Terminal',
       chains: [CHAIN],
-      walletPlugins: [walletPlugin]
+      walletPlugins: [walletPlugin],
+      ui: new SimpleUI()
     })
   }
   return sessionKit
@@ -126,6 +128,10 @@ export async function restoreSession() {
 
     } catch (error) {
         console.error('[Auth] Restore session failed:', error);
+        try {
+            const kit = getKit();
+            await kit.storage.remove('session');
+        } catch {}
         dispatchAuthChange(null);
         return null;
     }

--- a/src/simpleUI.js
+++ b/src/simpleUI.js
@@ -1,0 +1,27 @@
+import {AbstractUserInterface} from '@wharfkit/session'
+import {cancelable} from '@wharfkit/common'
+
+export class SimpleUI extends AbstractUserInterface {
+  async login(context) {
+    return {
+      walletPluginIndex: 0,
+      chainId: context.chain ? context.chain.id : context.chains[0].id,
+      permissionLevel: context.permissionLevel
+    }
+  }
+  async onError(error) { console.error('[UI]', error) }
+  async onAccountCreate() { return {} }
+  async onAccountCreateComplete() {}
+  async onLogin() {}
+  async onLoginComplete() {}
+  async onTransact() {}
+  async onTransactComplete() {}
+  async onSign() {}
+  async onSignComplete() {}
+  async onBroadcast() {}
+  async onBroadcastComplete() {}
+  prompt() { return cancelable(Promise.resolve({})) }
+  status() {}
+  translate(key, options) { return options?.default ?? key }
+  addTranslations() {}
+}


### PR DESCRIPTION
## Summary
- add a simple UserInterface implementation for SessionKit
- initialise SessionKit with the custom UI
- clear stale local storage on failed session restore
- avoid sending `Authorization` header when no GitHub token is set

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f5443e988832aa53a98310c024737